### PR TITLE
Validate handler inputs with user-friendly error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hardcover-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for the Hardcover GraphQL API — library tracking and list management."
 readme = "README.md"
 license = "MIT"

--- a/src/hardcover_mcp/tools/_validation.py
+++ b/src/hardcover_mcp/tools/_validation.py
@@ -1,0 +1,19 @@
+"""Shared input validation helpers for tool handlers."""
+
+from typing import Any
+
+
+def _require_int(value: Any, name: str) -> int:
+    """Convert a value to int or raise ValueError with a user-friendly message."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"'{name}' must be an integer, got: {value!r}") from None
+
+
+def _require_float(value: Any, name: str) -> float:
+    """Convert a value to float or raise ValueError with a user-friendly message."""
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"'{name}' must be a number, got: {value!r}") from None

--- a/src/hardcover_mcp/tools/_validation.py
+++ b/src/hardcover_mcp/tools/_validation.py
@@ -7,7 +7,7 @@ def _require_int(value: Any, name: str) -> int:
     """Convert a value to int or raise ValueError with a user-friendly message."""
     try:
         return int(value)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         raise ValueError(f"'{name}' must be an integer, got: {value!r}") from None
 
 
@@ -15,5 +15,5 @@ def _require_float(value: Any, name: str) -> float:
     """Convert a value to float or raise ValueError with a user-friendly message."""
     try:
         return float(value)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         raise ValueError(f"'{name}' must be a number, got: {value!r}") from None

--- a/src/hardcover_mcp/tools/books.py
+++ b/src/hardcover_mcp/tools/books.py
@@ -6,6 +6,7 @@ from typing import Any
 from mcp.types import TextContent
 
 from hardcover_mcp.client import execute
+from hardcover_mcp.tools._validation import _require_int
 
 SEARCH_BOOKS_QUERY = """
 query SearchBooks($query: String!, $per_page: Int!, $page: Int!) {
@@ -116,10 +117,13 @@ async def handle_get_book(arguments: dict[str, Any]) -> list[TextContent]:
     if not book_id and not slug:
         return [TextContent(type="text", text="Error: provide either 'id' or 'slug'.")]
 
-    if book_id:
-        result = await execute(GET_BOOK_BY_ID_QUERY, {"id": int(book_id)})
-    else:
-        result = await execute(GET_BOOK_BY_SLUG_QUERY, {"slug": slug})
+    try:
+        if book_id:
+            result = await execute(GET_BOOK_BY_ID_QUERY, {"id": _require_int(book_id, "id")})
+        else:
+            result = await execute(GET_BOOK_BY_SLUG_QUERY, {"slug": slug})
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
 
     books = result["data"]["books"]
     if not books:

--- a/src/hardcover_mcp/tools/library.py
+++ b/src/hardcover_mcp/tools/library.py
@@ -6,6 +6,7 @@ from typing import Any
 from mcp.types import TextContent
 
 from hardcover_mcp.client import execute
+from hardcover_mcp.tools._validation import _require_float, _require_int
 from hardcover_mcp.tools.user import get_current_user
 
 STATUS_MAP: dict[int, str] = {
@@ -232,13 +233,16 @@ async def handle_get_user_book(arguments: dict[str, Any]) -> list[TextContent]:
         book_id = books[0]["id"]
 
     user = await get_current_user()
-    result = await execute(
-        GET_USER_BOOK_QUERY,
-        {
-            "user_id": user["id"],
-            "book_id": int(book_id),
-        },
-    )
+    try:
+        result = await execute(
+            GET_USER_BOOK_QUERY,
+            {
+                "user_id": user["id"],
+                "book_id": _require_int(book_id, "book_id"),
+            },
+        )
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     user_books = result["data"]["user_books"]
     if not user_books:
         return [TextContent(type="text", text="Book not in your library.")]
@@ -335,12 +339,19 @@ async def handle_set_user_book(arguments: dict[str, Any]) -> list[TextContent]:
 
     rating = arguments.get("rating")
 
+    try:
+        book_id_int = _require_int(book_id, "book_id")
+        if rating is not None:
+            _require_float(rating, "rating")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
+
     # Check if user_book already exists
     existing = await execute(
         FIND_USER_BOOK_QUERY,
         {
             "user_id": user_id,
-            "book_id": int(book_id),
+            "book_id": book_id_int,
         },
     )
     existing_books = existing["data"]["user_books"]
@@ -351,7 +362,7 @@ async def handle_set_user_book(arguments: dict[str, Any]) -> list[TextContent]:
         obj: dict[str, Any] = {}
         obj["status_id"] = status_id if status_id is not None else current["status_id"]
         if rating is not None:
-            obj["rating"] = float(rating)
+            obj["rating"] = _require_float(rating, "rating")
         elif current.get("rating") is not None:
             obj["rating"] = current["rating"]
 
@@ -360,11 +371,11 @@ async def handle_set_user_book(arguments: dict[str, Any]) -> list[TextContent]:
         mutation_result = result["data"]["update_user_book"]
     else:
         obj = {}
-        obj["book_id"] = int(book_id)
+        obj["book_id"] = book_id_int
         if status_id is not None:
             obj["status_id"] = status_id
         if rating is not None:
-            obj["rating"] = float(rating)
+            obj["rating"] = _require_float(rating, "rating")
         result = await execute(INSERT_USER_BOOK_MUTATION, {"object": obj})
         mutation_result = result["data"]["insert_user_book"]
 
@@ -461,7 +472,9 @@ def _build_read_input(arguments: dict[str, Any]) -> dict[str, Any]:
     if arguments.get("finished_at"):
         read_input["finished_at"] = arguments["finished_at"]
     if arguments.get("progress_pages") is not None:
-        read_input["progress_pages"] = int(arguments["progress_pages"])
+        read_input["progress_pages"] = _require_int(
+            arguments["progress_pages"], "progress_pages"
+        )
     return read_input
 
 
@@ -472,7 +485,7 @@ async def _resolve_user_book_id(arguments: dict[str, Any]) -> int | str:
     """
     user_book_id = arguments.get("user_book_id")
     if user_book_id:
-        return int(user_book_id)
+        return _require_int(user_book_id, "user_book_id")
 
     book_id = arguments.get("book_id")
     if not book_id:
@@ -483,7 +496,7 @@ async def _resolve_user_book_id(arguments: dict[str, Any]) -> int | str:
         FIND_USER_BOOK_QUERY,
         {
             "user_id": user["id"],
-            "book_id": int(book_id),
+            "book_id": _require_int(book_id, "book_id"),
         },
     )
     ubs = existing["data"]["user_books"]
@@ -514,7 +527,10 @@ async def handle_add_user_book_read(arguments: dict[str, Any]) -> list[TextConte
         return [TextContent(type="text", text=resolved)]
     user_book_id = resolved
 
-    read_input = _build_read_input(arguments)
+    try:
+        read_input = _build_read_input(arguments)
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     if not read_input:
         return [
             TextContent(
@@ -577,7 +593,10 @@ async def handle_update_user_book_read(arguments: dict[str, Any]) -> list[TextCo
     if not read_id:
         return [TextContent(type="text", text="Error: 'id' (user_book_read id) is required.")]
 
-    read_input = _build_read_input(arguments)
+    try:
+        read_input = _build_read_input(arguments)
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     if not read_input:
         return [
             TextContent(
@@ -587,7 +606,12 @@ async def handle_update_user_book_read(arguments: dict[str, Any]) -> list[TextCo
         ]
 
     # Fetch current values and merge so unchanged fields aren't nulled out
-    current = await execute(GET_USER_BOOK_READ_QUERY, {"id": int(read_id)})
+    try:
+        read_id_int = _require_int(read_id, "id")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+    current = await execute(GET_USER_BOOK_READ_QUERY, {"id": read_id_int})
     current_reads = current["data"]["user_book_reads"]
     if not current_reads:
         return [TextContent(type="text", text="Error: no read entry found with that ID.")]
@@ -596,7 +620,7 @@ async def handle_update_user_book_read(arguments: dict[str, Any]) -> list[TextCo
     result = await execute(
         UPDATE_USER_BOOK_READ_MUTATION,
         {
-            "id": int(read_id),
+            "id": read_id_int,
             "object": merged,
         },
     )
@@ -648,8 +672,13 @@ async def handle_delete_user_book_read(arguments: dict[str, Any]) -> list[TextCo
     if not read_id:
         return [TextContent(type="text", text="Error: 'id' (user_book_read id) is required.")]
 
-    await execute(DELETE_USER_BOOK_READ_MUTATION, {"id": int(read_id)})
-    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": int(read_id)}))]
+    try:
+        read_id_int = _require_int(read_id, "id")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+    await execute(DELETE_USER_BOOK_READ_MUTATION, {"id": read_id_int})
+    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": read_id_int}))]
 
 
 async def handle_delete_user_book(arguments: dict[str, Any]) -> list[TextContent]:

--- a/src/hardcover_mcp/tools/library.py
+++ b/src/hardcover_mcp/tools/library.py
@@ -472,9 +472,7 @@ def _build_read_input(arguments: dict[str, Any]) -> dict[str, Any]:
     if arguments.get("finished_at"):
         read_input["finished_at"] = arguments["finished_at"]
     if arguments.get("progress_pages") is not None:
-        read_input["progress_pages"] = _require_int(
-            arguments["progress_pages"], "progress_pages"
-        )
+        read_input["progress_pages"] = _require_int(arguments["progress_pages"], "progress_pages")
     return read_input
 
 

--- a/src/hardcover_mcp/tools/lists.py
+++ b/src/hardcover_mcp/tools/lists.py
@@ -6,6 +6,7 @@ from typing import Any
 from mcp.types import TextContent
 
 from hardcover_mcp.client import execute
+from hardcover_mcp.tools._validation import _require_int
 from hardcover_mcp.tools.user import get_current_user
 
 PRIVACY_MAP = {
@@ -137,14 +138,17 @@ async def handle_get_list(arguments: dict[str, Any]) -> list[TextContent]:
     book_limit = min(arguments.get("book_limit", 25), 100)
     book_offset = arguments.get("book_offset", 0)
 
-    result = await execute(
-        GET_LIST_BY_ID_QUERY,
-        {
-            "id": int(list_id),
-            "book_limit": book_limit,
-            "book_offset": book_offset,
-        },
-    )
+    try:
+        result = await execute(
+            GET_LIST_BY_ID_QUERY,
+            {
+                "id": _require_int(list_id, "id"),
+                "book_limit": book_limit,
+                "book_offset": book_offset,
+            },
+        )
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
 
     lists = result["data"]["lists"]
     if not lists:
@@ -294,7 +298,12 @@ async def handle_update_list(arguments: dict[str, Any]) -> list[TextContent]:
             )
         ]
 
-    result = await execute(UPDATE_LIST_MUTATION, {"id": int(list_id), "object": obj})
+    try:
+        result = await execute(
+            UPDATE_LIST_MUTATION, {"id": _require_int(list_id, "id"), "object": obj}
+        )
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     mutation_result = result["data"]["update_list"]
 
     lst = mutation_result.get("list", {})
@@ -325,9 +334,14 @@ async def handle_delete_list(arguments: dict[str, Any]) -> list[TextContent]:
     if not list_id:
         return [TextContent(type="text", text="Error: 'id' is required.")]
 
-    await execute(DELETE_LIST_MUTATION, {"id": int(list_id)})
+    try:
+        list_id_int = _require_int(list_id, "id")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
 
-    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": int(list_id)}))]
+    await execute(DELETE_LIST_MUTATION, {"id": list_id_int})
+
+    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": list_id_int}))]
 
 
 # ── Write: list books ──
@@ -385,12 +399,15 @@ async def handle_add_book_to_list(arguments: dict[str, Any]) -> list[TextContent
     if not list_id or not book_id:
         return [TextContent(type="text", text="Error: 'list_id' and 'book_id' are required.")]
 
-    obj: dict[str, Any] = {
-        "list_id": int(list_id),
-        "book_id": int(book_id),
-    }
-    if arguments.get("position") is not None:
-        obj["position"] = int(arguments["position"])
+    try:
+        obj: dict[str, Any] = {
+            "list_id": _require_int(list_id, "list_id"),
+            "book_id": _require_int(book_id, "book_id"),
+        }
+        if arguments.get("position") is not None:
+            obj["position"] = _require_int(arguments["position"], "position")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
 
     result = await execute(INSERT_LIST_BOOK_MUTATION, {"object": obj})
     mutation_result = result["data"]["insert_list_book"]
@@ -426,18 +443,26 @@ async def handle_remove_book_from_list(arguments: dict[str, Any]) -> list[TextCo
                     text="Error: provide 'id' (list_book id) or both 'list_id' and 'book_id'.",
                 )
             ]
-        result = await execute(
-            FIND_LIST_BOOK_QUERY,
-            {
-                "list_id": int(list_id),
-                "book_id": int(book_id),
-            },
-        )
+        try:
+            result = await execute(
+                FIND_LIST_BOOK_QUERY,
+                {
+                    "list_id": _require_int(list_id, "list_id"),
+                    "book_id": _require_int(book_id, "book_id"),
+                },
+            )
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Error: {e}")]
         lbs = result["data"]["list_books"]
         if not lbs:
             return [TextContent(type="text", text="Error: book not found in that list.")]
         list_book_id = lbs[0]["id"]
 
-    result = await execute(DELETE_LIST_BOOK_MUTATION, {"id": int(list_book_id)})
+    try:
+        list_book_id_int = _require_int(list_book_id, "id")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
 
-    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": int(list_book_id)}))]
+    result = await execute(DELETE_LIST_BOOK_MUTATION, {"id": list_book_id_int})
+
+    return [TextContent(type="text", text=json.dumps({"deleted": True, "id": list_book_id_int}))]

--- a/tests/tools/test_books.py
+++ b/tests/tools/test_books.py
@@ -48,9 +48,7 @@ class TestHandleSearchBooks:
 
     @patch("hardcover_mcp.tools.books.execute", new_callable=AsyncMock)
     async def test_caps_per_page_at_25(self, mock_execute):
-        mock_execute.return_value = {
-            "data": {"search": {"results": {"hits": [], "found": 0}}}
-        }
+        mock_execute.return_value = {"data": {"search": {"results": {"hits": [], "found": 0}}}}
 
         await handle_search_books({"query": "test", "per_page": 100})
 

--- a/tests/tools/test_books.py
+++ b/tests/tools/test_books.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from hardcover_mcp.tools.books import _format_search_hit, handle_search_books
+from hardcover_mcp.tools.books import _format_search_hit, handle_get_book, handle_search_books
 
 
 class TestFormatSearchHit:
@@ -56,3 +56,10 @@ class TestHandleSearchBooks:
 
         call_vars = mock_execute.call_args[0][1]
         assert call_vars["per_page"] == 25
+
+
+class TestHandleGetBook:
+    async def test_returns_error_on_non_numeric_id(self):
+        result = await handle_get_book({"id": "not-a-number"})
+
+        assert "must be an integer" in result[0].text

--- a/tests/tools/test_library.py
+++ b/tests/tools/test_library.py
@@ -1,7 +1,6 @@
 """Tests for tools/library.py — status resolution, formatting, input building."""
 
 from hardcover_mcp.tools.library import (
-    STATUS_MAP,
     _build_read_input,
     _format_user_book,
     _merge_read_input,
@@ -91,3 +90,9 @@ class TestBuildReadInput:
 
     def test_returns_empty_when_no_read_fields(self):
         assert _build_read_input({"book_id": 42}) == {}
+
+    def test_raises_on_non_numeric_progress_pages(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="'progress_pages' must be an integer"):
+            _build_read_input({"progress_pages": "abc"})

--- a/tests/tools/test_lists.py
+++ b/tests/tools/test_lists.py
@@ -3,7 +3,6 @@
 import pytest
 
 from hardcover_mcp.tools.lists import (
-    PRIVACY_MAP,
     _build_list_input,
     _format_list_book,
     _format_list_summary,

--- a/tests/tools/test_validation.py
+++ b/tests/tools/test_validation.py
@@ -1,0 +1,44 @@
+"""Tests for tools/_validation.py — _require_int and _require_float."""
+
+import pytest
+
+from hardcover_mcp.tools._validation import _require_float, _require_int
+
+
+class TestRequireInt:
+    def test_converts_int(self):
+        assert _require_int(42, "x") == 42
+
+    def test_converts_numeric_string(self):
+        assert _require_int("42", "x") == 42
+
+    def test_raises_on_non_numeric_string(self):
+        with pytest.raises(ValueError, match="'book_id' must be an integer"):
+            _require_int("abc", "book_id")
+
+    def test_raises_on_none(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _require_int(None, "id")
+
+    def test_raises_on_float_string(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _require_int("3.5", "id")
+
+
+class TestRequireFloat:
+    def test_converts_float(self):
+        assert _require_float(4.5, "x") == 4.5
+
+    def test_converts_int_to_float(self):
+        assert _require_float(4, "x") == 4.0
+
+    def test_converts_numeric_string(self):
+        assert _require_float("3.5", "x") == 3.5
+
+    def test_raises_on_non_numeric_string(self):
+        with pytest.raises(ValueError, match="'rating' must be a number"):
+            _require_float("abc", "rating")
+
+    def test_raises_on_none(self):
+        with pytest.raises(ValueError, match="must be a number"):
+            _require_float(None, "rating")

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "hardcover-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
All bare `int()` / `float()` calls in tool handlers now go through `_require_int` /
`_require_float` helpers that return clear error messages instead of unhandled tracebacks.

## Problem

Passing a non-numeric value (e.g. `"abc"`) to any handler expecting an integer ID would
produce a raw `ValueError` traceback — confusing for end users and unhelpful for debugging.

## Changes

- **New:** `tools/_validation.py` with `_require_int` and `_require_float` helpers
- **books.py** — `handle_get_book`
- **library.py** — `handle_get_user_book`, `handle_set_user_book`, `_build_read_input`,
  `_resolve_user_book_id`, `handle_add_user_book_read`, `handle_update_user_book_read`,
  `handle_delete_user_book_read`
- **lists.py** — `handle_get_list`, `handle_update_list`, `handle_delete_list`,
  `handle_add_book_to_list`, `handle_remove_book_from_list`
- **12 new tests** covering validation helpers and handler error paths
- Version bump: 0.1.0 → 0.1.1