### PR TITLE
Add get_series tool for series browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Add to `claude_desktop_config.json`:
 | `get_user_book` | Get your library entry for a specific book (status, rating, reading dates) |
 | `get_my_lists` | Get all of your Hardcover lists |
 | `get_list` | Get a specific list with its books |
+| `get_series` | Get a book series by id, slug, or name with books in reading order |
 
 ### Write
 

--- a/src/hardcover_mcp/server.py
+++ b/src/hardcover_mcp/server.py
@@ -28,6 +28,7 @@ from hardcover_mcp.tools.lists import (
     handle_remove_book_from_list,
     handle_update_list,
 )
+from hardcover_mcp.tools.series import handle_get_series
 from hardcover_mcp.tools.user import handle_me
 
 server = Server("hardcover")
@@ -181,6 +182,30 @@ TOOL_REGISTRY: list[tuple[Tool, Handler]] = [
             },
         ),
         handle_get_list,
+    ),
+    (
+        Tool(
+            name="get_series",
+            description="Get a book series by id, slug, or name with books in reading order.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "description": "Hardcover series ID.",
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Series slug (e.g. 'the-stormlight-archive').",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Exact series name (e.g. 'The Stormlight Archive').",
+                    },
+                },
+            },
+        ),
+        handle_get_series,
     ),
     # ── Write: library ──
     (

--- a/src/hardcover_mcp/tools/series.py
+++ b/src/hardcover_mcp/tools/series.py
@@ -1,0 +1,165 @@
+"""Tools: get_series."""
+
+import json
+from typing import Any
+
+from mcp.types import TextContent
+
+from hardcover_mcp.client import execute
+from hardcover_mcp.tools._validation import _require_int
+
+# ── Read: get_series by id or slug ──
+
+GET_SERIES_BY_ID_QUERY = """
+query GetSeriesById($id: Int!) {
+    series(where: {id: {_eq: $id}}, limit: 1) {
+        id
+        name
+        slug
+        description
+        books_count
+        primary_books_count
+        is_completed
+        author {
+            name
+            slug
+        }
+        book_series(
+            distinct_on: position
+            order_by: [{position: asc}, {book: {users_count: desc}}]
+            where: {
+                book: {canonical_id: {_is_null: true}, is_partial_book: {_eq: false}},
+                compilation: {_eq: false}
+            }
+        ) {
+            position
+            book {
+                id
+                slug
+                title
+                release_year
+                rating
+                users_count
+            }
+        }
+    }
+}
+"""
+
+GET_SERIES_BY_SLUG_QUERY = GET_SERIES_BY_ID_QUERY.replace(
+    "GetSeriesById($id: Int!)", "GetSeriesBySlug($slug: String!)"
+).replace("{id: {_eq: $id}}", "{slug: {_eq: $slug}}")
+
+# Name lookup may return multiple results — pick the best candidate.
+GET_SERIES_BY_NAME_QUERY = """
+query GetSeriesByName($name: String!) {
+    series(
+        where: {
+            name: {_eq: $name},
+            books_count: {_gt: 0},
+            canonical_id: {_is_null: true}
+        },
+        order_by: [{primary_books_count: desc_nulls_last}, {books_count: desc}],
+        limit: 5
+    ) {
+        id
+        name
+        slug
+        description
+        books_count
+        primary_books_count
+        is_completed
+        author {
+            name
+            slug
+        }
+        book_series(
+            distinct_on: position
+            order_by: [{position: asc}, {book: {users_count: desc}}]
+            where: {
+                book: {canonical_id: {_is_null: true}, is_partial_book: {_eq: false}},
+                compilation: {_eq: false}
+            }
+        ) {
+            position
+            book {
+                id
+                slug
+                title
+                release_year
+                rating
+                users_count
+            }
+        }
+    }
+}
+"""
+
+
+def _format_series(s: dict[str, Any]) -> dict[str, Any]:
+    """Format a raw series record into a structured response dict."""
+    author = s.get("author") or {}
+    books = [
+        {
+            "position": bs.get("position"),
+            "book_id": bs["book"]["id"],
+            "slug": bs["book"]["slug"],
+            "title": bs["book"]["title"],
+            "release_year": bs["book"].get("release_year"),
+            "rating": bs["book"].get("rating"),
+        }
+        for bs in s.get("book_series", [])
+    ]
+    return {
+        "id": s["id"],
+        "name": s["name"],
+        "slug": s["slug"],
+        "description": s.get("description"),
+        "books_count": s["books_count"],
+        "primary_books_count": s.get("primary_books_count"),
+        "is_completed": s.get("is_completed"),
+        "author": author.get("name"),
+        "author_slug": author.get("slug"),
+        "books": books,
+    }
+
+
+async def handle_get_series(arguments: dict[str, Any]) -> list[TextContent]:
+    """Fetch a series by id, slug, or exact name, including books in order.
+
+    Parameters
+    ----------
+    arguments : dict[str, Any]
+        Provide one of: ``id`` (int), ``slug`` (str), or ``name`` (str).
+
+    Returns
+    -------
+    list[TextContent]
+        JSON with series metadata and a ``books`` array in position order.
+    """
+    series_id = arguments.get("id")
+    slug = arguments.get("slug")
+    name = arguments.get("name")
+
+    if not series_id and not slug and not name:
+        return [TextContent(type="text", text="Error: provide 'id', 'slug', or 'name'.")]
+
+    if series_id:
+        try:
+            result = await execute(GET_SERIES_BY_ID_QUERY, {"id": _require_int(series_id, "id")})
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Error: {e}")]
+        series_list = result["data"]["series"]
+    elif slug:
+        result = await execute(GET_SERIES_BY_SLUG_QUERY, {"slug": slug})
+        series_list = result["data"]["series"]
+    else:
+        result = await execute(GET_SERIES_BY_NAME_QUERY, {"name": name})
+        series_list = result["data"]["series"]
+
+    if not series_list:
+        return [TextContent(type="text", text="No series found.")]
+
+    # Name lookups return multiple candidates; take the top-ranked one.
+    output = _format_series(series_list[0])
+    return [TextContent(type="text", text=json.dumps(output, indent=2))]

--- a/tests/integration/test_read_tools.py
+++ b/tests/integration/test_read_tools.py
@@ -118,7 +118,33 @@ class TestGetMyLists:
             lst = data[0]
             assert "id" in lst
             assert "name" in lst
-            assert "privacy" in lst
+
+
+class TestGetSeries:
+    async def test_get_series_by_slug(self):
+        from hardcover_mcp.tools.series import handle_get_series
+
+        result = await handle_get_series({"slug": "the-stormlight-archive"})
 
         data = json.loads(result[0].text)
-        assert isinstance(data, list)
+        assert data["name"] == "The Stormlight Archive"
+        assert data["slug"] == "the-stormlight-archive"
+        assert len(data["books"]) > 0
+        # Books are sorted by position; first position should be the lowest
+        assert data["books"][0]["position"] is not None
+
+    async def test_get_series_by_name(self):
+        from hardcover_mcp.tools.series import handle_get_series
+
+        result = await handle_get_series({"name": "Harry Potter"})
+
+        data = json.loads(result[0].text)
+        assert "Harry Potter" in data["name"]
+        assert data["books_count"] > 0
+
+    async def test_get_series_returns_error_without_args(self):
+        from hardcover_mcp.tools.series import handle_get_series
+
+        result = await handle_get_series({})
+
+        assert "Error" in result[0].text

--- a/tests/integration/test_write_tools.py
+++ b/tests/integration/test_write_tools.py
@@ -51,7 +51,6 @@ class TestListLifecycle:
             handle_add_book_to_list,
             handle_create_list,
             handle_delete_list,
-            handle_get_list,
             handle_remove_book_from_list,
             handle_update_list,
         )
@@ -60,11 +59,13 @@ class TestListLifecycle:
         list_name = f"_test_integration_{unique}"
 
         # 1. Create
-        result = await handle_create_list({
-            "name": list_name,
-            "description": "Temporary test list",
-            "privacy": "private",
-        })
+        result = await handle_create_list(
+            {
+                "name": list_name,
+                "description": "Temporary test list",
+                "privacy": "private",
+            }
+        )
         created = json.loads(result[0].text)
         list_id = created["id"]
         assert created["name"] == list_name
@@ -73,28 +74,34 @@ class TestListLifecycle:
         try:
             # 2. Update
             updated_name = f"_test_integration_{unique}_updated"
-            result = await handle_update_list({
-                "id": list_id,
-                "name": updated_name,
-            })
+            result = await handle_update_list(
+                {
+                    "id": list_id,
+                    "name": updated_name,
+                }
+            )
             updated = json.loads(result[0].text)
             assert updated["name"] == updated_name
 
             # 3. Add book
             book_id = await _find_book_not_in_library()
-            result = await handle_add_book_to_list({
-                "list_id": list_id,
-                "book_id": book_id,
-            })
+            result = await handle_add_book_to_list(
+                {
+                    "list_id": list_id,
+                    "book_id": book_id,
+                }
+            )
             list_book = json.loads(result[0].text)
             list_book_id = list_book["id"]
             assert list_book["book_id"] == book_id
             assert list_book["list_id"] == list_id
 
             # 4. Remove book
-            result = await handle_remove_book_from_list({
-                "id": list_book_id,
-            })
+            result = await handle_remove_book_from_list(
+                {
+                    "id": list_book_id,
+                }
+            )
             removed = json.loads(result[0].text)
             assert removed["deleted"] is True
 
@@ -118,20 +125,24 @@ class TestUserBookLifecycle:
         book_id = await _find_book_not_in_library()
 
         # 1. Add to library
-        result = await handle_set_user_book({
-            "book_id": book_id,
-            "status": "Want to Read",
-        })
+        result = await handle_set_user_book(
+            {
+                "book_id": book_id,
+                "status": "Want to Read",
+            }
+        )
         created = json.loads(result[0].text)
         user_book_id = created["user_book_id"]
         assert created["status"] == "Want to Read"
 
         try:
             # 2. Update rating
-            result = await handle_set_user_book({
-                "book_id": book_id,
-                "rating": 4.0,
-            })
+            result = await handle_set_user_book(
+                {
+                    "book_id": book_id,
+                    "rating": 4.0,
+                }
+            )
             updated = json.loads(result[0].text)
             assert updated["rating"] == 4.0
 

--- a/tests/tools/test_series.py
+++ b/tests/tools/test_series.py
@@ -1,0 +1,100 @@
+"""Unit tests for tools.series."""
+
+from hardcover_mcp.tools.series import _format_series
+
+
+class TestFormatSeries:
+    def test_formats_full_series(self):
+        raw = {
+            "id": 42,
+            "name": "The Stormlight Archive",
+            "slug": "the-stormlight-archive",
+            "description": "Epic fantasy series",
+            "books_count": 10,
+            "primary_books_count": 4,
+            "is_completed": False,
+            "author": {"name": "Brandon Sanderson", "slug": "brandon-sanderson"},
+            "book_series": [
+                {
+                    "position": 1,
+                    "book": {
+                        "id": 100,
+                        "slug": "the-way-of-kings",
+                        "title": "The Way of Kings",
+                        "release_year": 2010,
+                        "rating": 4.65,
+                        "users_count": 50000,
+                    },
+                },
+                {
+                    "position": 2,
+                    "book": {
+                        "id": 101,
+                        "slug": "words-of-radiance",
+                        "title": "Words of Radiance",
+                        "release_year": 2014,
+                        "rating": 4.76,
+                        "users_count": 40000,
+                    },
+                },
+            ],
+        }
+
+        result = _format_series(raw)
+
+        assert result["id"] == 42
+        assert result["name"] == "The Stormlight Archive"
+        assert result["slug"] == "the-stormlight-archive"
+        assert result["author"] == "Brandon Sanderson"
+        assert result["author_slug"] == "brandon-sanderson"
+        assert result["is_completed"] is False
+        assert result["primary_books_count"] == 4
+        assert len(result["books"]) == 2
+        assert result["books"][0]["position"] == 1
+        assert result["books"][0]["title"] == "The Way of Kings"
+        assert result["books"][1]["position"] == 2
+
+    def test_handles_missing_author(self):
+        raw = {
+            "id": 1,
+            "name": "Test Series",
+            "slug": "test-series",
+            "description": None,
+            "books_count": 0,
+            "primary_books_count": None,
+            "is_completed": None,
+            "author": None,
+            "book_series": [],
+        }
+
+        result = _format_series(raw)
+
+        assert result["author"] is None
+        assert result["author_slug"] is None
+        assert result["books"] == []
+
+    def test_excludes_users_count_from_output(self):
+        raw = {
+            "id": 1,
+            "name": "S",
+            "slug": "s",
+            "books_count": 1,
+            "author": None,
+            "book_series": [
+                {
+                    "position": 1,
+                    "book": {
+                        "id": 10,
+                        "slug": "b",
+                        "title": "B",
+                        "release_year": 2020,
+                        "rating": 4.0,
+                        "users_count": 999,
+                    },
+                },
+            ],
+        }
+
+        result = _format_series(raw)
+
+        assert "users_count" not in result["books"][0]


### PR DESCRIPTION
Closes #4

Adds a `get_series` tool that fetches a series by id, slug, or exact name and returns books in reading order.

### What it does

- **Query by id, slug, or name** — name lookups disambiguate by `primary_books_count` / `books_count`
- **Books in position order** — deduped using `distinct_on: position` per the [API guide](https://docs.hardcover.app/api/guides/gettingbooksinseries/)
- **Filters out noise** — merged books (`canonical_id`), partial books, and compilations are excluded

### Files changed

- `src/hardcover_mcp/tools/series.py` — GraphQL queries, `_format_series`, `handle_get_series`
- `src/hardcover_mcp/server.py` — Tool registration
- `tests/tools/test_series.py` — 3 unit tests for `_format_series`
- `tests/integration/test_read_tools.py` — 3 integration tests (slug, name, error case)