### PR TITLE
Add get_author tool for author lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `get_author` tool — look up an author by id, slug, or name; returns bio, book counts, and books sorted by popularity.
 - `get_series` tool — browse a book series by name, look up which series an author
   has written, or find the series a specific book belongs to.
 - Integration test suite covering all read tools and account-safe write tools.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Add to `claude_desktop_config.json`:
 | `get_my_lists` | Get all of your Hardcover lists |
 | `get_list` | Get a specific list with its books |
 | `get_series` | Get a book series by id, slug, or name with books in reading order |
+| `get_author` | Get an author's details and books by Hardcover ID, slug, or name |
 
 ### Write
 
@@ -76,7 +77,7 @@ Add to `claude_desktop_config.json`:
 
 ## Scope
 
-This server focuses on library tracking and list management. Features like social (followers, feed), recommendations, and edition management are not currently supported.
+This server focuses on library tracking, list management, and book/author discovery. Features like social (followers, feed), recommendations, and edition management are not currently supported.
 
 ## Development
 

--- a/src/hardcover_mcp/server.py
+++ b/src/hardcover_mcp/server.py
@@ -9,6 +9,7 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
+from hardcover_mcp.tools.authors import handle_get_author
 from hardcover_mcp.tools.books import handle_get_book, handle_search_books
 from hardcover_mcp.tools.library import (
     handle_add_user_book_read,
@@ -206,6 +207,34 @@ TOOL_REGISTRY: list[tuple[Tool, Handler]] = [
             },
         ),
         handle_get_series,
+    ),
+    (
+        Tool(
+            name="get_author",
+            description="Get an author's details and books by Hardcover ID, slug, or name.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "description": "Hardcover author ID.",
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Author slug (e.g. 'brandon-sanderson').",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Author name (e.g. 'Brandon Sanderson').",
+                    },
+                    "books_limit": {
+                        "type": "integer",
+                        "description": "Max books to return (default 20, max 100).",
+                    },
+                },
+            },
+        ),
+        handle_get_author,
     ),
     # ── Write: library ──
     (

--- a/src/hardcover_mcp/tools/authors.py
+++ b/src/hardcover_mcp/tools/authors.py
@@ -1,0 +1,172 @@
+"""Tools: get_author."""
+
+import json
+from typing import Any
+
+from mcp.types import TextContent
+
+from hardcover_mcp.client import execute
+from hardcover_mcp.tools._validation import _require_int
+
+# ── Read: get_author by id, slug, or name ──
+
+_AUTHOR_FIELDS = """
+        id
+        slug
+        name
+        bio
+        books_count
+        users_count
+        born_year
+        death_year
+        contributions(
+            order_by: {book: {users_count: desc_nulls_last}},
+            limit: $books_limit
+        ) {
+            book {
+                id
+                slug
+                title
+                rating
+                release_year
+            }
+        }
+"""
+
+GET_AUTHOR_BY_ID_QUERY = (
+    """
+query GetAuthorById($id: Int!, $books_limit: Int!) {
+    authors(where: {id: {_eq: $id}}, limit: 1) {"""
+    + _AUTHOR_FIELDS
+    + """    }
+}
+"""
+)
+
+GET_AUTHOR_BY_SLUG_QUERY = (
+    """
+query GetAuthorBySlug($slug: String!, $books_limit: Int!) {
+    authors(where: {slug: {_eq: $slug}}, limit: 1) {"""
+    + _AUTHOR_FIELDS
+    + """    }
+}
+"""
+)
+
+# Name lookup may return multiple candidates — rank by books_count then users_count.
+# Uses _eq (exact, case-sensitive) for name matching, consistent with series name lookup.
+GET_AUTHOR_BY_NAME_QUERY = (
+    """
+query GetAuthorByName($name: String!, $books_limit: Int!) {
+    authors(
+        where: {
+            name: {_eq: $name}
+        },
+        order_by: [
+            {books_count: desc_nulls_last},
+            {users_count: desc_nulls_last}
+        ],
+        limit: 5
+    ) {"""
+    + _AUTHOR_FIELDS
+    + """    }
+}
+"""
+)
+
+_DEFAULT_BOOKS_LIMIT = 20
+_MAX_BOOKS_LIMIT = 100
+
+
+def _format_author(a: dict[str, Any]) -> dict[str, Any]:
+    """Format a raw author record into a structured response dict.
+
+    Parameters
+    ----------
+    a : dict[str, Any]
+        A single record from the ``authors`` GraphQL response. Expected keys:
+        ``id``, ``slug``, ``name``, ``bio``, ``books_count``, ``users_count``,
+        ``born_year``, ``death_year``, ``contributions`` (list of
+        ``{book: {id, slug, title, rating, release_year}}``).
+
+    Returns
+    -------
+    dict[str, Any]
+        Flattened author dict with a ``books`` list. Contributions with a null
+        ``book`` are silently dropped. ``users_count`` is excluded from each
+        book entry — it is used for ordering only and is not user-facing.
+    """
+    books = [
+        {
+            "book_id": c["book"]["id"],
+            "slug": c["book"]["slug"],
+            "title": c["book"]["title"],
+            "release_year": c["book"].get("release_year"),
+            "rating": c["book"].get("rating"),
+        }
+        for c in a.get("contributions", [])
+        if c.get("book")
+    ]
+    return {
+        "id": a["id"],
+        "slug": a["slug"],
+        "name": a["name"],
+        "bio": a.get("bio"),
+        "books_count": a.get("books_count"),
+        "users_count": a.get("users_count"),
+        "born_year": a.get("born_year"),
+        "death_year": a.get("death_year"),
+        "books": books,
+    }
+
+
+async def handle_get_author(arguments: dict[str, Any]) -> list[TextContent]:
+    """Fetch an author by id, slug, or name, including their books by popularity.
+
+    Parameters
+    ----------
+    arguments : dict[str, Any]
+        Provide one of: ``id`` (int), ``slug`` (str), or ``name`` (str).
+        Optional: ``books_limit`` (int, default 20, max 100).
+
+    Returns
+    -------
+    list[TextContent]
+        JSON with author metadata and a ``books`` array sorted by popularity.
+    """
+    author_id = arguments.get("id")
+    slug = arguments.get("slug")
+    name = arguments.get("name")
+
+    if not author_id and not slug and not name:
+        return [TextContent(type="text", text="Error: provide 'id', 'slug', or 'name'.")]
+
+    try:
+        books_limit = min(
+            _require_int(arguments.get("books_limit", _DEFAULT_BOOKS_LIMIT), "books_limit"),
+            _MAX_BOOKS_LIMIT,
+        )
+    except ValueError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+    vars: dict[str, Any] = {"books_limit": books_limit}
+    if author_id:
+        try:
+            vars["id"] = _require_int(author_id, "id")
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Error: {e}")]
+        result = await execute(GET_AUTHOR_BY_ID_QUERY, vars)
+    elif slug:
+        vars["slug"] = slug
+        result = await execute(GET_AUTHOR_BY_SLUG_QUERY, vars)
+    else:
+        vars["name"] = name
+        result = await execute(GET_AUTHOR_BY_NAME_QUERY, vars)
+
+    authors = result["data"]["authors"]
+    if not authors:
+        return [TextContent(type="text", text="No author found.")]
+
+    # Name lookups return multiple ranked candidates; take the top result.
+    output = _format_author(authors[0])
+    return [TextContent(type="text", text=json.dumps(output, indent=2))]

--- a/tests/integration/test_read_tools.py
+++ b/tests/integration/test_read_tools.py
@@ -99,6 +99,64 @@ class TestGetUserLibrary:
         assert data["returned"] <= 2
 
 
+class TestGetSeries:
+    async def test_get_series_by_slug(self):
+        from hardcover_mcp.tools.series import handle_get_series
+
+        result = await handle_get_series({"slug": "the-stormlight-archive"})
+
+        data = json.loads(result[0].text)
+        assert data["name"] == "The Stormlight Archive"
+        assert isinstance(data["books"], list)
+        assert len(data["books"]) > 0
+
+    async def test_get_series_by_name(self):
+        from hardcover_mcp.tools.series import handle_get_series
+
+        result = await handle_get_series({"name": "Mistborn"})
+
+        data = json.loads(result[0].text)
+        assert "name" in data
+        assert isinstance(data["books"], list)
+
+
+class TestGetAuthor:
+    async def test_get_author_by_slug(self):
+        from hardcover_mcp.tools.authors import handle_get_author
+
+        result = await handle_get_author({"slug": "brandon-sanderson"})
+
+        data = json.loads(result[0].text)
+        assert data["name"] == "Brandon Sanderson"
+        assert data["slug"] == "brandon-sanderson"
+        assert isinstance(data["books"], list)
+        assert len(data["books"]) > 0
+
+    async def test_get_author_by_name(self):
+        from hardcover_mcp.tools.authors import handle_get_author
+
+        result = await handle_get_author({"name": "Andy Weir"})
+
+        data = json.loads(result[0].text)
+        assert data["name"] == "Andy Weir"
+        assert isinstance(data["books"], list)
+
+    async def test_get_author_respects_books_limit(self):
+        from hardcover_mcp.tools.authors import handle_get_author
+
+        result = await handle_get_author({"slug": "brandon-sanderson", "books_limit": 3})
+
+        data = json.loads(result[0].text)
+        assert len(data["books"]) <= 3
+
+    async def test_unknown_author_returns_not_found(self):
+        from hardcover_mcp.tools.authors import handle_get_author
+
+        result = await handle_get_author({"slug": "zzz-does-not-exist-zzz"})
+
+        assert "No author found" in result[0].text
+
+
 class TestGetMyLists:
     async def test_returns_lists(self):
         from hardcover_mcp.tools.lists import handle_get_my_lists

--- a/tests/tools/test_authors.py
+++ b/tests/tools/test_authors.py
@@ -1,0 +1,127 @@
+"""Unit tests for tools.authors."""
+
+from hardcover_mcp.tools.authors import _format_author
+
+
+class TestFormatAuthor:
+    def test_formats_full_author(self):
+        raw = {
+            "id": 1,
+            "slug": "brandon-sanderson",
+            "name": "Brandon Sanderson",
+            "bio": "American fantasy author.",
+            "books_count": 50,
+            "users_count": 200000,
+            "born_year": 1975,
+            "death_year": None,
+            "contributions": [
+                {
+                    "book": {
+                        "id": 100,
+                        "slug": "the-way-of-kings",
+                        "title": "The Way of Kings",
+                        "release_year": 2010,
+                        "rating": 4.65,
+                    }
+                },
+                {
+                    "book": {
+                        "id": 101,
+                        "slug": "mistborn",
+                        "title": "Mistborn",
+                        "release_year": 2006,
+                        "rating": 4.45,
+                    }
+                },
+            ],
+        }
+
+        result = _format_author(raw)
+
+        assert result["id"] == 1
+        assert result["slug"] == "brandon-sanderson"
+        assert result["name"] == "Brandon Sanderson"
+        assert result["bio"] == "American fantasy author."
+        assert result["books_count"] == 50
+        assert result["users_count"] == 200000
+        assert result["born_year"] == 1975
+        assert result["death_year"] is None
+        assert len(result["books"]) == 2
+        assert result["books"][0]["title"] == "The Way of Kings"
+        assert result["books"][0]["book_id"] == 100
+        assert result["books"][1]["title"] == "Mistborn"
+
+    def test_handles_no_contributions(self):
+        raw = {
+            "id": 2,
+            "slug": "unknown-author",
+            "name": "Unknown Author",
+            "bio": None,
+            "books_count": 0,
+            "users_count": 0,
+            "born_year": None,
+            "death_year": None,
+            "contributions": [],
+        }
+
+        result = _format_author(raw)
+
+        assert result["books"] == []
+        assert result["bio"] is None
+        assert result["born_year"] is None
+
+    def test_skips_contributions_with_null_book(self):
+        raw = {
+            "id": 3,
+            "slug": "some-author",
+            "name": "Some Author",
+            "bio": None,
+            "books_count": 1,
+            "users_count": 10,
+            "born_year": None,
+            "death_year": None,
+            "contributions": [
+                {"book": None},
+                {
+                    "book": {
+                        "id": 10,
+                        "slug": "a-book",
+                        "title": "A Book",
+                        "release_year": 2020,
+                        "rating": 3.5,
+                    }
+                },
+            ],
+        }
+
+        result = _format_author(raw)
+
+        assert len(result["books"]) == 1
+        assert result["books"][0]["title"] == "A Book"
+
+    def test_book_fields_do_not_include_users_count(self):
+        raw = {
+            "id": 4,
+            "slug": "author",
+            "name": "Author",
+            "bio": None,
+            "books_count": 1,
+            "users_count": 5,
+            "born_year": None,
+            "death_year": None,
+            "contributions": [
+                {
+                    "book": {
+                        "id": 20,
+                        "slug": "book",
+                        "title": "Book",
+                        "release_year": 2021,
+                        "rating": 4.0,
+                    }
+                }
+            ],
+        }
+
+        result = _format_author(raw)
+
+        assert "users_count" not in result["books"][0]


### PR DESCRIPTION
Closes #9

### What

Adds a `get_author` tool that fetches author details by Hardcover ID, slug, or exact name, including their books sorted by popularity.

### Tool signature

```
get_author(id?: int, slug?: str, name?: str, books_limit?: int = 20)
```

### Fields returned

- `id`, `slug`, `name`, `bio`
- `books_count`, `users_count`, `born_year`, `death_year`
- `books` — list of contributions ordered by `users_count` descending, each with `book_id`, `slug`, `title`, `release_year`, `rating`

### Notes

- Name lookups use `_eq` (exact match) and rank candidates by `books_count` then `users_count`, returning the top result. The `canonical_id` filter was omitted — it causes a 403 on the public API.
- `books_limit` is capped at 100; defaults to 20.
- Follows the same handler/formatter/query structure as `get_series`.

### Tests

- 4 unit tests for `_format_author` (full record, no contributions, null book entries, field exclusion)
- 4 integration tests (by slug, by name, `books_limit` respected, unknown slug returns "not found")