### PR TITLE
chore: remove unused name-lookup query constants

### DIFF
--- a/src/hardcover_mcp/tools/authors.py
+++ b/src/hardcover_mcp/tools/authors.py
@@ -54,27 +54,6 @@ query GetAuthorBySlug($slug: String!, $books_limit: Int!) {
 """
 )
 
-# Name lookup may return multiple candidates — rank by books_count then users_count.
-# Uses _eq (exact, case-sensitive) for name matching, consistent with series name lookup.
-GET_AUTHOR_BY_NAME_QUERY = (
-    """
-query GetAuthorByName($name: String!, $books_limit: Int!) {
-    authors(
-        where: {
-            name: {_eq: $name}
-        },
-        order_by: [
-            {books_count: desc_nulls_last},
-            {users_count: desc_nulls_last}
-        ],
-        limit: 5
-    ) {"""
-    + _AUTHOR_FIELDS
-    + """    }
-}
-"""
-)
-
 _DEFAULT_BOOKS_LIMIT = 20
 _MAX_BOOKS_LIMIT = 100
 

--- a/src/hardcover_mcp/tools/series.py
+++ b/src/hardcover_mcp/tools/series.py
@@ -51,51 +51,6 @@ GET_SERIES_BY_SLUG_QUERY = GET_SERIES_BY_ID_QUERY.replace(
     "GetSeriesById($id: Int!)", "GetSeriesBySlug($slug: String!)"
 ).replace("{id: {_eq: $id}}", "{slug: {_eq: $slug}}")
 
-# Name lookup may return multiple results — pick the best candidate.
-GET_SERIES_BY_NAME_QUERY = """
-query GetSeriesByName($name: String!) {
-    series(
-        where: {
-            name: {_eq: $name},
-            books_count: {_gt: 0},
-            canonical_id: {_is_null: true}
-        },
-        order_by: [{primary_books_count: desc_nulls_last}, {books_count: desc}],
-        limit: 5
-    ) {
-        id
-        name
-        slug
-        description
-        books_count
-        primary_books_count
-        is_completed
-        author {
-            name
-            slug
-        }
-        book_series(
-            distinct_on: position
-            order_by: [{position: asc}, {book: {users_count: desc}}]
-            where: {
-                book: {canonical_id: {_is_null: true}, is_partial_book: {_eq: false}},
-                compilation: {_eq: false}
-            }
-        ) {
-            position
-            book {
-                id
-                slug
-                title
-                release_year
-                rating
-                users_count
-            }
-        }
-    }
-}
-"""
-
 
 def _format_series(s: dict[str, Any]) -> dict[str, Any]:
     """Format a raw series record into a structured response dict."""


### PR DESCRIPTION
Removes `GET_SERIES_BY_NAME_QUERY` and `GET_AUTHOR_BY_NAME_QUERY` — dead code after #17 switched name lookups to the Typesense search() endpoint.

66 lines deleted, no behavior change.